### PR TITLE
stopping and starting instead of immediate restarting

### DIFF
--- a/src/main/scala/kitties/DrawingMain.scala
+++ b/src/main/scala/kitties/DrawingMain.scala
@@ -25,14 +25,16 @@ object DrawingMain extends JFXApp {
   val startButton = new Button("Start!")
   startButton.onAction = { _ =>
     if (hasStarted) {
+      kittyActors.foreach(kitty => kitty ! Stop)
+      hasStarted = false
+      startButton.text = "Start!"
+    } else {
       val negativeScore = 0 - this.score
       updateScore(negativeScore)
-      kittyActors.foreach(kitty => kitty ! ReStart)
-    } else {
       hasStarted = true
       startKitties()
       kittyActors.foreach(kitty => kitty ! Start)
-      startButton.text = "Restart!"
+      startButton.text = "Stop!"
     }
   }
 


### PR DESCRIPTION
- dodane pole 'cancellable' w KittyActor przechowujące scheduler mający wywołać NextFrame
- ReStart zamieniony na Stop, w handleStop dodane cancellable.cancel() anulujące kolejne wywołanie NextFrame
- startButton pokazuje Stop, a nie Restart po zaczęciu gry
- w związku z tym po naciśnięciu Stop kotki zatrzymują się do momentu ponownego naciśnięcia Start, wtedy gra zaczyna się od nowa tak jak za pierwszym razem, a nie od razu tak jak to było z Restart
- Score zeruje się dopiero po ponownym naciśnięciu Start, żeby gracz mógł zobaczyć jaki wynik uzyskał