### PR TITLE
Another refactor

### DIFF
--- a/src/main/scala/kitties/DrawingMain.scala
+++ b/src/main/scala/kitties/DrawingMain.scala
@@ -1,6 +1,6 @@
 package kitties
 
-import scalafx.Includes._
+//import scalafx.Includes._
 import kitties.ActorManager.{getKittiesPanel, prepareKittyActors, startKitties, stopAll, terminateActorSystem}
 import scalafx.animation.AnimationTimer
 import scalafx.application.JFXApp

--- a/src/main/scala/kitties/DrawingMain.scala
+++ b/src/main/scala/kitties/DrawingMain.scala
@@ -1,6 +1,5 @@
 package kitties
 
-//import scalafx.Includes._
 import kitties.ActorManager.{getKittiesPanel, prepareKittyActors, startKitties, stopAll, terminateActorSystem}
 import scalafx.animation.AnimationTimer
 import scalafx.application.JFXApp

--- a/src/main/scala/kitties/KittiesPanelActor.scala
+++ b/src/main/scala/kitties/KittiesPanelActor.scala
@@ -1,6 +1,7 @@
 package kitties
 
 import akka.actor.Actor
+import kitties.KITTY_X_MATCHER.{firstKittyMatched, secondKittyMatched, thirdKittyMatched, fourthKittyMatched, fifthKittyMatched}
 import scalafx.Includes._
 import scalafx.application.Platform
 import scalafx.scene.input.MouseEvent
@@ -22,23 +23,19 @@ class KittiesPanelActor(kittiesPanel: KittiesPanel) extends Actor {
     }
   }
 
-  def matchKittyX(x: Double): Int = {
+  def matchKitty(x: Double): Int = {
     x match {
-      case x if INITIAL_KITTIES_X < x && x < (KITTY_WIDTH + INITIAL_KITTIES_X) => 1
-      case x if (SPACE_BETWEEN_KITTIES + INITIAL_KITTIES_X + KITTY_WIDTH) < x &&
-        x < (INITIAL_KITTIES_X + SPACE_BETWEEN_KITTIES + KITTY_WIDTH * 2) => 2
-      case x if x < (SPACE_BETWEEN_KITTIES * 2 + INITIAL_KITTIES_X + KITTY_WIDTH * 3) &&
-        x > (INITIAL_KITTIES_X + SPACE_BETWEEN_KITTIES * 2 + KITTY_WIDTH * 2) => 3
-      case x if x < (SPACE_BETWEEN_KITTIES * 3 + INITIAL_KITTIES_X + KITTY_WIDTH * 4) &&
-        x > (INITIAL_KITTIES_X + SPACE_BETWEEN_KITTIES * 3 + KITTY_WIDTH * 3) => 4
-      case x if x < (WINDOW_WIDTH - SPACE_BETWEEN_KITTIES) &&
-        x > (INITIAL_KITTIES_X + SPACE_BETWEEN_KITTIES * 4 + KITTY_WIDTH * 4) => 5
+      case x if firstKittyMatched(x) => 1
+      case x if secondKittyMatched(x) => 2
+      case x if thirdKittyMatched(x) => 3
+      case x if fourthKittyMatched(x) => 4
+      case x if fifthKittyMatched(x) => 5
       case _ => 0
     }
   }
 
   kittiesPanel.onMouseClicked = (me: MouseEvent) => {
-    val matchedKitty = matchKittyX(me.x)
+    val matchedKitty = matchKitty(me.x)
     matchedKitty match {
       case 0 =>
       case 1 => context.system.actorSelection("user/" + KITTY_ACTOR_NAMES(0)) ! Clicked

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -60,4 +60,31 @@ package object kitties {
 
   val ANIMATION_LENGTH: Int = ANIMATION_FRAMES.length
 
+  object KITTY_X_MATCHER {
+    def firstKittyMatched(x: Double): Boolean = {
+      INITIAL_KITTIES_X < x && x < (KITTY_WIDTH + INITIAL_KITTIES_X)
+    }
+
+    def secondKittyMatched(x: Double): Boolean = {
+      (SPACE_BETWEEN_KITTIES + INITIAL_KITTIES_X + KITTY_WIDTH) < x &&
+        x < (INITIAL_KITTIES_X + SPACE_BETWEEN_KITTIES + KITTY_WIDTH * 2)
+    }
+
+    def thirdKittyMatched(x: Double): Boolean = {
+      (INITIAL_KITTIES_X + SPACE_BETWEEN_KITTIES * 2 + KITTY_WIDTH * 2) < x &&
+        x < (SPACE_BETWEEN_KITTIES * 2 + INITIAL_KITTIES_X + KITTY_WIDTH * 3)
+    }
+
+    def fourthKittyMatched(x: Double): Boolean = {
+      (INITIAL_KITTIES_X + SPACE_BETWEEN_KITTIES * 3 + KITTY_WIDTH * 3) < x &&
+        x < (SPACE_BETWEEN_KITTIES * 3 + INITIAL_KITTIES_X + KITTY_WIDTH * 4)
+    }
+
+    def fifthKittyMatched(x: Double): Boolean = {
+      (INITIAL_KITTIES_X + SPACE_BETWEEN_KITTIES * 4 + KITTY_WIDTH * 4) < x &&
+        x < (WINDOW_WIDTH - SPACE_BETWEEN_KITTIES)
+    }
+  }
+
+
 }

--- a/src/test/scala/KittyActorTests.scala
+++ b/src/test/scala/KittyActorTests.scala
@@ -23,7 +23,7 @@ class KittyActorTests extends TestKit(ActorSystem("test-system"))
     val kittiesPanel = new KittiesPanel
     val kittiesPanelActor = system.actorOf(Props(new KittiesPanelActor(kittiesPanel)))
     val kittyActor = system.actorOf(Props(new KittyActor(0, Color.Blue, 0, kittiesPanelActor) {
-      override def handleClick(): Unit = {
+      override def handleClick(frameIndex: Int): Unit = {
         probe.ref ! "msg"
       }
     }))
@@ -37,7 +37,7 @@ class KittyActorTests extends TestKit(ActorSystem("test-system"))
     val kittiesPanel = new KittiesPanel
     val kittiesPanelActor = system.actorOf(Props(new KittiesPanelActor(kittiesPanel)))
     val kittyActor = system.actorOf(Props(new KittyActor(0, Color.Blue, 0, kittiesPanelActor) {
-      override def handleClick(): Unit = {
+      override def handleClick(frameIndex: Int): Unit = {
         probe.ref ! "msg"
       }
     }))
@@ -54,7 +54,7 @@ class KittyActorTests extends TestKit(ActorSystem("test-system"))
     val kittiesPanel = new KittiesPanel
     val kittiesPanelActor = system.actorOf(Props(new KittiesPanelActor(kittiesPanel)))
     val kittyActor = system.actorOf(Props(new KittyActor(0, Color.Blue, 0, kittiesPanelActor) {
-      override def handleFrameChange(hasStarted: Boolean): Unit = {
+      override def handleFrameChange(hasStarted: Boolean, loops: Int, frameIndex: Int): Unit = {
         import system.dispatcher
         system.scheduler.scheduleOnce(1000.millis)(probe.ref ! NextFrame)
       }
@@ -117,7 +117,7 @@ class KittyActorTests extends TestKit(ActorSystem("test-system"))
   it should "not change frame when stopped" in {
     val probe = TestProbe()
     val kittyActor = system.actorOf(Props(new KittyActor(0, Color.Blue, 0, probe.ref) {
-      override def handleFrameChange(hasStarted: Boolean): Unit = {
+      override def handleFrameChange(hasStarted: Boolean, loops: Int, frameIndex: Int): Unit = {
         import system.dispatcher
         system.scheduler.scheduleOnce(1000.millis)(probe.ref ! NextFrame)
       }

--- a/src/test/scala/KittyActorTests.scala
+++ b/src/test/scala/KittyActorTests.scala
@@ -54,7 +54,7 @@ class KittyActorTests extends TestKit(ActorSystem("test-system"))
     val kittiesPanel = new KittiesPanel
     val kittiesPanelActor = system.actorOf(Props(new KittiesPanelActor(kittiesPanel)))
     val kittyActor = system.actorOf(Props(new KittyActor(0, Color.Blue, 0, kittiesPanelActor) {
-      override def handleFrameChange(hasStarted: Boolean): Unit = {
+      override def handleFrameChange(hasStarted: Boolean, loops: Int): Unit = {
         import system.dispatcher
         system.scheduler.scheduleOnce(1000.millis)(probe.ref ! NextFrame)
       }
@@ -117,7 +117,7 @@ class KittyActorTests extends TestKit(ActorSystem("test-system"))
   it should "not change frame when stopped" in {
     val probe = TestProbe()
     val kittyActor = system.actorOf(Props(new KittyActor(0, Color.Blue, 0, probe.ref) {
-      override def handleFrameChange(hasStarted: Boolean): Unit = {
+      override def handleFrameChange(hasStarted: Boolean, loops: Int): Unit = {
         import system.dispatcher
         system.scheduler.scheduleOnce(1000.millis)(probe.ref ! NextFrame)
       }

--- a/src/test/scala/KittyActorTests.scala
+++ b/src/test/scala/KittyActorTests.scala
@@ -23,7 +23,7 @@ class KittyActorTests extends TestKit(ActorSystem("test-system"))
     val kittiesPanel = new KittiesPanel
     val kittiesPanelActor = system.actorOf(Props(new KittiesPanelActor(kittiesPanel)))
     val kittyActor = system.actorOf(Props(new KittyActor(0, Color.Blue, 0, kittiesPanelActor) {
-      override def handleClick(frameIndex: Int): Unit = {
+      override def handleClick(): Unit = {
         probe.ref ! "msg"
       }
     }))
@@ -37,7 +37,7 @@ class KittyActorTests extends TestKit(ActorSystem("test-system"))
     val kittiesPanel = new KittiesPanel
     val kittiesPanelActor = system.actorOf(Props(new KittiesPanelActor(kittiesPanel)))
     val kittyActor = system.actorOf(Props(new KittyActor(0, Color.Blue, 0, kittiesPanelActor) {
-      override def handleClick(frameIndex: Int): Unit = {
+      override def handleClick(): Unit = {
         probe.ref ! "msg"
       }
     }))
@@ -54,7 +54,7 @@ class KittyActorTests extends TestKit(ActorSystem("test-system"))
     val kittiesPanel = new KittiesPanel
     val kittiesPanelActor = system.actorOf(Props(new KittiesPanelActor(kittiesPanel)))
     val kittyActor = system.actorOf(Props(new KittyActor(0, Color.Blue, 0, kittiesPanelActor) {
-      override def handleFrameChange(hasStarted: Boolean, loops: Int, frameIndex: Int): Unit = {
+      override def handleFrameChange(hasStarted: Boolean): Unit = {
         import system.dispatcher
         system.scheduler.scheduleOnce(1000.millis)(probe.ref ! NextFrame)
       }
@@ -117,7 +117,7 @@ class KittyActorTests extends TestKit(ActorSystem("test-system"))
   it should "not change frame when stopped" in {
     val probe = TestProbe()
     val kittyActor = system.actorOf(Props(new KittyActor(0, Color.Blue, 0, probe.ref) {
-      override def handleFrameChange(hasStarted: Boolean, loops: Int, frameIndex: Int): Unit = {
+      override def handleFrameChange(hasStarted: Boolean): Unit = {
         import system.dispatcher
         system.scheduler.scheduleOnce(1000.millis)(probe.ref ! NextFrame)
       }


### PR DESCRIPTION
*general cleanup* :broom:
- [x] unused import statements
- [x] `matchKitty` => sprawdzane warunki przeniesione do package'u 📦
- [x] `loops` nie jest już *actor mutable state*, tylko parametrem wywołania zmiany klatki (podobno tak się to powinno robić)